### PR TITLE
PokemonType Entity에 typeNumber를 추가한다.

### DIFF
--- a/urmine-backend/src/main/java/com/urmine/db/entity/PokemonType.java
+++ b/urmine-backend/src/main/java/com/urmine/db/entity/PokemonType.java
@@ -14,5 +14,6 @@ public class PokemonType {
     Pokemon pokemon;
 
     @Id
+    Integer typeNumber;
     String pokemonType;
 }

--- a/urmine-backend/src/main/java/com/urmine/db/entity/PokemonTypeId.java
+++ b/urmine-backend/src/main/java/com/urmine/db/entity/PokemonTypeId.java
@@ -11,5 +11,5 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class PokemonTypeId implements Serializable {
     Long pokemon;
-    String pokemonType;
+    Integer typeNumber;
 }


### PR DESCRIPTION
+ PokemonType Entity에 Integer 변수인 typeNumber를 추가한다.
+ PokemonType의 Key를 (pokemonId, pokemonType) 에서 (pokemonId, typeNumber)로 변경한다.
  + DB 저장 시 자동 정렬되는 문제 발생
  + ex) 타입이 (바위, 땅), (땅, 바위)인 포켓몬이 존재하여 순서를 유지하기 위함