### PR TITLE
SwaggerConfiguration을 추가한다.

### DIFF
--- a/urmine-backend/build.gradle
+++ b/urmine-backend/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation ("io.springfox:springfox-swagger-ui:3.0.0")
     implementation("io.swagger:swagger-annotations:1.5.21")
     implementation("io.swagger:swagger-models:1.5.21")
+    implementation("com.google.guava:guava:29.0-jre")
+    annotationProcessor("com.google.guava:guava:29.0-jre")
 }
 
 tasks.named('test') {

--- a/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
+++ b/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
@@ -3,7 +3,13 @@ package com.urmine.config;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 /*
  * Swagger 설정을 위한 SwaggerConfig
@@ -11,6 +17,20 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
+    public static final String SECURITY_SCHEMA_NAME = "JWT";
+    public static final String AUTHORIZATION_SCOPE_GLOBAL = "global";
+    public static final String AUTHORIZATION_SCOPE_GLOBAL_DESC = "accessEverything";
+
+    private List<SecurityReference> defaultAuth() {
+        /*
+         * 요청에 포함되는 헤더를 전역으로 사용할 수 있도록 설정하는 메소드
+         */
+        AuthorizationScope authorizationScope = new AuthorizationScope(AUTHORIZATION_SCOPE_GLOBAL, AUTHORIZATION_SCOPE_GLOBAL_DESC);
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return newArrayList(new SecurityReference(SECURITY_SCHEMA_NAME, authorizationScopes));
+    }
+
     private ApiInfo apiInfo() {
         /*
          * API의 정보를 반환하는 메소드

--- a/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
+++ b/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.AuthorizationScope;
 import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.List;
@@ -20,6 +21,15 @@ public class SwaggerConfig {
     public static final String SECURITY_SCHEMA_NAME = "JWT";
     public static final String AUTHORIZATION_SCOPE_GLOBAL = "global";
     public static final String AUTHORIZATION_SCOPE_GLOBAL_DESC = "accessEverything";
+
+    private SecurityContext securityContext() {
+        /*
+         * 보안 정보를 담아 전송하는 메소드
+         */
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
 
     private List<SecurityReference> defaultAuth() {
         /*

--- a/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
+++ b/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
@@ -1,12 +1,17 @@
 package com.urmine.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
 import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.List;
@@ -22,6 +27,21 @@ public class SwaggerConfig {
     public static final String SECURITY_SCHEMA_NAME = "JWT";
     public static final String AUTHORIZATION_SCOPE_GLOBAL = "global";
     public static final String AUTHORIZATION_SCOPE_GLOBAL_DESC = "accessEverything";
+
+    @Bean
+    public Docket api() {
+        /*
+         * 해당 경로를 가지는 클래스에 Swagger를 적용하는 메소드
+         */
+        return new Docket(DocumentationType.OAS_30)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.urmine.api.controller"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo())
+                .securitySchemes(newArrayList(apiKey()))
+                .securityContexts(newArrayList(securityContext()));
+    }
 
     private ApiKey apiKey() {
         /*

--- a/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
+++ b/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
@@ -1,6 +1,8 @@
 package com.urmine.config;
 
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /*
@@ -9,5 +11,14 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
-    
+    private ApiInfo apiInfo() {
+        /*
+         * API의 정보를 반환하는 메소드
+         */
+        return new ApiInfoBuilder()
+                .title("U R Mine!")
+                .description("포켓몬 띠브띠브씰 도감")
+                .version("v1.0")
+                .build();
+    }
 }

--- a/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
+++ b/urmine-backend/src/main/java/com/urmine/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.urmine.config;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
 import springfox.documentation.service.AuthorizationScope;
 import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.service.contexts.SecurityContext;
@@ -21,6 +22,13 @@ public class SwaggerConfig {
     public static final String SECURITY_SCHEMA_NAME = "JWT";
     public static final String AUTHORIZATION_SCOPE_GLOBAL = "global";
     public static final String AUTHORIZATION_SCOPE_GLOBAL_DESC = "accessEverything";
+
+    private ApiKey apiKey() {
+        /*
+         * Swagger에서 JWT 인증을 추가하는 메소드
+         */
+        return new ApiKey(SECURITY_SCHEMA_NAME, "Authorization", "header");
+    }
 
     private SecurityContext securityContext() {
         /*


### PR DESCRIPTION
+ newArrayList 객체 사용을 위해 com.google.guava 의존성을 추가한다.
+ Swagger에 표시될 ApiInfo를 반환하는 메소드를 추가한다.
+ 요청에 포함되는 헤더를 전역으로 사용할 수 있도록 설정하는 메소드를 추가한다.
+ defaultAuth를 담아 전송하는 securityContext 메소드를 추가한다.
+ Swagger에 JWT 인증을 추가한다.
+ 패키지에 포함되는 클래스에 Swagger를 적용한다.