### PR TITLE
PokemonGetResponseDto를 생성한다.

### DIFF
--- a/urmine-backend/src/main/java/com/urmine/api/response/pokemon/PokemonGetRes.java
+++ b/urmine-backend/src/main/java/com/urmine/api/response/pokemon/PokemonGetRes.java
@@ -1,0 +1,44 @@
+package com.urmine.api.response.pokemon;
+
+import com.urmine.api.response.pokemonevolution.PokemonEvolutionGetRes;
+import com.urmine.api.response.pokemonpicture.PokemonPictureGetRes;
+import com.urmine.api.response.pokemontype.PokemonTypeGetRes;
+import com.urmine.db.entity.Pokemon;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+ * 포켓몬의 정보를 조회하기 위한 ResponseDto
+ */
+@Data
+@Builder
+public class PokemonGetRes {
+    private Long pokemonId;
+    private String pokemonName;
+    private String kind;
+    private String color;
+    private String description;
+    private List<PokemonEvolutionGetRes> pokemonEvolutionGetResList;
+    private List<PokemonTypeGetRes> pokemonTypeGetResList;
+    private List<PokemonPictureGetRes> pokemonPictureGetResList;
+
+    public static PokemonGetRes of(Pokemon pokemon) {
+        /*
+         * Pokemon Entity를 PokemonGetResponseDto로 변환하는 메소드
+         * pokemonEvolution은 PokemonService에서 조회
+         */
+
+        return PokemonGetRes.builder()
+                .pokemonId(pokemon.getPokemonId())
+                .pokemonName(pokemon.getPokemonName())
+                .kind(pokemon.getKind())
+                .color(pokemon.getColor())
+                .description(pokemon.getDescription())
+                .pokemonTypeGetResList(pokemon.getPokemonTypeList().stream().map(pokemonType -> PokemonTypeGetRes.of(pokemonType)).collect(Collectors.toList()))
+                .pokemonPictureGetResList(pokemon.getPokemonPictureList().stream().map(pokemonPicture -> PokemonPictureGetRes.of(pokemonPicture)).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/urmine-backend/src/main/java/com/urmine/api/response/pokemonevolution/PokemonEvolutionGetRes.java
+++ b/urmine-backend/src/main/java/com/urmine/api/response/pokemonevolution/PokemonEvolutionGetRes.java
@@ -1,0 +1,34 @@
+package com.urmine.api.response.pokemonevolution;
+
+import com.urmine.db.entity.PokemonEvolution;
+import lombok.Builder;
+import lombok.Data;
+
+/*
+ * 특정 포켓몬의 진화 정보를 조회하기 위한 ResponseDto
+ */
+@Data
+@Builder
+public class PokemonEvolutionGetRes {
+    private Long pokemonId;
+    private String firstMethod;
+    private Long firstEvolutionId;
+    private String secondMethod;
+    private Long secondEvolutionId;
+
+    public static PokemonEvolutionGetRes of(PokemonEvolution pokemonEvolution) {
+        /*
+         * PokemonEvolution Entity를 PokemonEvolutionGetResponseDto로 변환하는 메소드
+         */
+
+        if (pokemonEvolution == null) return null;
+
+        return PokemonEvolutionGetRes.builder()
+                .pokemonId(pokemonEvolution.getPokemon().getPokemonId())
+                .firstMethod(pokemonEvolution.getFirstMethod())
+                .firstEvolutionId(pokemonEvolution.getFirstEvolutionId())
+                .secondMethod(pokemonEvolution.getSecondMethod())
+                .secondEvolutionId(pokemonEvolution.getSecondEvolutionId())
+                .build();
+    }
+}

--- a/urmine-backend/src/main/java/com/urmine/api/response/pokemonpicture/PokemonPictureGetRes.java
+++ b/urmine-backend/src/main/java/com/urmine/api/response/pokemonpicture/PokemonPictureGetRes.java
@@ -1,0 +1,30 @@
+package com.urmine.api.response.pokemonpicture;
+
+import com.urmine.db.entity.PokemonPicture;
+import lombok.Builder;
+import lombok.Data;
+
+/*
+ * 특정 포켓몬의 이미지 URL을 조회하기 위한 ResponseDto
+ */
+@Data
+@Builder
+public class PokemonPictureGetRes {
+    private Long pokemonId;
+    private Integer pokemonNum;
+    private String pokemonGrayImageUrl;
+    private String pokemonColorImageUrl;
+
+    public static PokemonPictureGetRes of(PokemonPicture pokemonPicture) {
+        /*
+         * PokemonPicture Entity를 PokemonPictureGetResponseDto로 변환하는 메소드
+         */
+
+        return PokemonPictureGetRes.builder()
+                .pokemonId(pokemonPicture.getPokemon().getPokemonId())
+                .pokemonNum(pokemonPicture.getPokemonNum())
+                .pokemonGrayImageUrl(pokemonPicture.getPokemonGrayImageUrl())
+                .pokemonColorImageUrl(pokemonPicture.getPokemonColorImageUrl())
+                .build();
+    }
+}

--- a/urmine-backend/src/main/java/com/urmine/api/response/pokemontype/PokemonTypeGetRes.java
+++ b/urmine-backend/src/main/java/com/urmine/api/response/pokemontype/PokemonTypeGetRes.java
@@ -1,0 +1,28 @@
+package com.urmine.api.response.pokemontype;
+
+import com.urmine.db.entity.PokemonType;
+import lombok.Builder;
+import lombok.Data;
+
+/*
+ * 특정 포켓몬의 타입을 조회하기 위한 ResponseDto
+ */
+@Data
+@Builder
+public class PokemonTypeGetRes {
+    private Long pokemonId;
+    private Integer typeNumber;
+    private String pokemonType;
+
+    public static PokemonTypeGetRes of(PokemonType pokemonType) {
+        /*
+         * PokemonType Entity를 PokemonTypeGetResponseDto로 변환하는 메소드
+         */
+
+        return PokemonTypeGetRes.builder()
+                .pokemonId(pokemonType.getPokemon().getPokemonId())
+                .typeNumber(pokemonType.getTypeNumber())
+                .pokemonType(pokemonType.getPokemonType())
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
+ 특정 포켓몬의 진화 정보 조회를 위한 PokemonEvolutionGetResponseDto를 생성한다.
+ 특정 포켓몬의 이미지 URL을 조회하기 위한 PokemonPictureGetResponseDto를 생성한다.
+ 특정 포켓몬의 타입을 조회하기 위한 PokemonTypeGetResponseDto를 생성한다.
+ 위 정보들을 포함하는 포켓몬을 조회하기 위한 PokemomGetResponseDto를 생성한다.

## 추후 진행할 내용
+ 포켓몬 조회를 위한 API 구현
